### PR TITLE
Add associations between Child and Item models (old)

### DIFF
--- a/app/controllers/partners/children_controller.rb
+++ b/app/controllers/partners/children_controller.rb
@@ -86,7 +86,8 @@ module Partners
         :last_name,
         :race,
         :archived,
-        child_lives_with: []
+        child_lives_with: [],
+        item_ids: []
       )
     end
 

--- a/app/controllers/partners/family_requests_controller.rb
+++ b/app/controllers/partners/family_requests_controller.rb
@@ -11,6 +11,9 @@ module Partners
         params[:filterrific]
       ) || return
       @children = @filterrific.find
+
+      @children_items = flash[:children_items] || {}
+      @error_messages = flash[:error_messages]
     end
 
     def create
@@ -38,7 +41,10 @@ module Partners
       if create_service.errors.none?
         redirect_to partners_request_path(create_service.partner_request), notice: "Requested items successfully!"
       else
-        redirect_to new_partners_family_request_path, error: "Request failed! #{create_service.errors.map { |error| error.message.to_s }}}"
+        # Save the original request data in the flash to repopulate the form upon redirection
+        flash[:children_items] = children_items
+        flash[:error_messages] = create_service.errors.full_messages.join(", ")
+        redirect_to new_partners_family_request_path
       end
     end
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -46,6 +46,8 @@ class Item < ApplicationRecord
   has_many :storage_locations, through: :inventory_items
   has_many :donations, through: :line_items, source: :itemizable, source_type: "::Donation"
   has_many :distributions, through: :line_items, source: :itemizable, source_type: "::Distribution"
+  has_many :children_items, class_name: "Partners::ChildrenItem", dependent: :destroy
+  has_many :children, through: :children_items, source: :child
 
   scope :active, -> { where(active: true) }
 

--- a/app/models/partners/child.rb
+++ b/app/models/partners/child.rb
@@ -25,6 +25,8 @@ module Partners
     serialize :child_lives_with, Array
     belongs_to :family
     has_many :child_item_requests, dependent: :destroy
+    has_many :children_items, class_name: 'Partners::ChildrenItem', dependent: :destroy
+    has_many :items, through: :children_items
 
     include Filterable
     include Exportable
@@ -114,4 +116,3 @@ module Partners
     end
   end
 end
-

--- a/app/models/partners/children_item.rb
+++ b/app/models/partners/children_item.rb
@@ -1,0 +1,6 @@
+module Partners
+  class ChildrenItem < ApplicationRecord
+    belongs_to :child, class_name: "Partners::Child"
+    belongs_to :item, class_name: "Item"
+  end
+end

--- a/app/views/layouts/partners/application.html.erb
+++ b/app/views/layouts/partners/application.html.erb
@@ -64,9 +64,11 @@
 
   <div class="content-wrapper">
     <% flash.each do |key, value| %>
+      <!-- Ensure value is a string and sanitized for HTML rendering -->
+      <% message = value.is_a?(Hash) ? value.to_s : sanitize(value, tags: %w(ul li)) %>
       <div class="<%= flash_class(key) %> alert-dismissible fade show" role="alert">
         <a href="#" class="close btn-close" data-bs-dismiss="alert" aria-label="Close" style="text-decoration: none;"><%= fa_icon('times') %></a>
-        <%= sanitize(value, tags: %w(ul li)) %>
+        <%= message.html_safe %> <!-- Now safely calling html_safe on a string -->
       </div>
     <% end %>
     <%= yield %>

--- a/app/views/partners/children/_form.html.erb
+++ b/app/views/partners/children/_form.html.erb
@@ -17,9 +17,7 @@
               <%= form.text_field :last_name, class: "form-control" %>
 
               <%= form.label :item_needed, "Diaper/Item Used" %>
-              <%= form.select :item_needed_diaperid, @requestable_items,
-                              {include_blank: 'Select an item'},
-                              {class: 'form-control'} %>
+              <%= form.select :item_ids, @requestable_items, {}, { multiple: true, class: 'form-control' } %>
               <br>
 
               <%= form.input :date_of_birth, as: :date, start_year: 20.years.ago.year, end_year: Time.current.year, label: "Date of Birth" %>

--- a/app/views/partners/children/show.html.erb
+++ b/app/views/partners/children/show.html.erb
@@ -59,7 +59,11 @@
                     <dd><%= @child.health_insurance %></dd>
 
                     <dt>Item needed:</dt>
-                    <dd><%= current_partner.organization.item_id_to_display_string_map[@child.item_needed_diaperid] %></dd>
+                    <ul>
+                      <% @child.items.each do |item| %>
+                        <li><%= item.name %></li> <!-- Assuming your item model has a 'name' attribute -->
+                      <% end %>
+                    </ul>
 
                     <dt>Comments:</dt>
                     <dd><%= @child.comments %></dd>

--- a/app/views/partners/family_requests/_list.html.erb
+++ b/app/views/partners/family_requests/_list.html.erb
@@ -1,3 +1,11 @@
+<% if @error_messages %>
+  <div class="alert alert-danger" role="alert">
+    <% @error_messages.each do |message| %>
+      <%= message %><br>
+    <% end %>
+  </div>
+<% end %>
+
 <table class='table table-striped'>
   <thead>
     <tr>
@@ -20,9 +28,10 @@
                 </td>
                 <td style="width: 200px;">
                   <div class="custom-control custom-switch form-switch">
-                    <%= check_box_tag "include_item_#{child.id}_#{item.id}", item.id, false,
-                                        class: "custom-control-input",
-                                        id: "include_item_#{child.id}_#{item.id}" %>
+                    <%= check_box_tag "children_items[#{child.id}][]", item.id,
+                                      @children_items.fetch(child.id.to_s, []).include?(item.id.to_s),
+                                      class: "custom-control-input",
+                                      id: "include_item_#{child.id}_#{item.id}" %>
                     <label class="custom-control-label" for="include_item_<%= child.id %>_<%= item.id %>">
                       Include this item for <%= child.first_name %>?
                     </label>

--- a/app/views/partners/family_requests/_list.html.erb
+++ b/app/views/partners/family_requests/_list.html.erb
@@ -1,42 +1,38 @@
 <table class='table table-striped'>
   <thead>
-  <tr>
-    <th>Guardian</th>
-    <th>Child</th>
-    <th>Item Needed</th>
-    <th>Include This Child?</th>
-  </tr>
+    <tr>
+      <th>Guardian</th>
+      <th>Child</th>
+      <th colspan="2">Items Needed</th>
+    </tr>
   </thead>
   <tbody class='fields'>
-  <% @children.each_with_index do |child, index| %>
-    <tr>
-      <td>
-        <%= child.family.guardian_first_name %>
-        <%= child.family.guardian_last_name %>
-      </td>
-      <td>
-        <%= child.first_name %> <%= child.last_name %>
-      </td>
-      <td>
-        <% if child.item_needed_diaperid %>
-          <%= current_partner.organization.item_id_to_display_string_map[child.item_needed_diaperid] %>
-        <% else %>
-          <%= "N/A" %>
-        <% end %>
-      </td>
-      <td>
-        <div class="custom-control custom-switch form-switch">
-          <% if child.item_needed_diaperid %>
-            <%= check_box_tag "child-#{child.id}", child.active, child.active,
-                              class: "custom-control-input",
-                              id: "child-#{child.id}" %>
-                            <label class="custom-control-label" for="child-<%= child.id %>">
-                              <span class="sr-only">Include This Child?</span>
-                            </label>
-          <% end %>
-        </div>
-      </td>
-    </tr>
-  <% end %>
+    <% @children.each_with_index do |child, index| %>
+      <tr>
+        <td><%= child.family.guardian_first_name %> <%= child.family.guardian_last_name %></td>
+        <td><%= child.first_name %> <%= child.last_name %></td>
+        <td colspan="2"> <!-- This colspan allows us to use the space for the 'Item Needed' column -->
+          <table class="table">
+            <% child.items.each do |item| %>
+              <tr>
+                <td>
+                  <%= item.name %>
+                </td>
+                <td style="width: 200px;">
+                  <div class="custom-control custom-switch form-switch">
+                    <%= check_box_tag "include_item_#{child.id}_#{item.id}", item.id, false,
+                                        class: "custom-control-input",
+                                        id: "include_item_#{child.id}_#{item.id}" %>
+                    <label class="custom-control-label" for="include_item_<%= child.id %>_<%= item.id %>">
+                      Include this item for <%= child.first_name %>?
+                    </label>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+          </table>
+        </td>
+      </tr>
+    <% end %>
   </tbody>
 </table>

--- a/db/migrate/20240404134355_create_children_items.rb
+++ b/db/migrate/20240404134355_create_children_items.rb
@@ -1,0 +1,10 @@
+class CreateChildrenItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :children_items do |t|
+      t.references :child, null: false, foreign_key: { to_table: :children }
+      t.references :item, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_20_193521) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_04_134355) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -186,6 +186,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_20_193521) do
     t.boolean "active", default: true
     t.boolean "archived"
     t.index ["family_id"], name: "index_children_on_family_id"
+  end
+
+  create_table "children_items", force: :cascade do |t|
+    t.bigint "child_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["child_id"], name: "index_children_items_on_child_id"
+    t.index ["item_id"], name: "index_children_items_on_item_id"
   end
 
   create_table "counties", force: :cascade do |t|
@@ -865,6 +874,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_20_193521) do
   add_foreign_key "child_item_requests", "children"
   add_foreign_key "child_item_requests", "item_requests"
   add_foreign_key "children", "families"
+  add_foreign_key "children_items", "children"
+  add_foreign_key "children_items", "items"
   add_foreign_key "distributions", "partners"
   add_foreign_key "distributions", "storage_locations"
   add_foreign_key "donations", "manufacturers"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -287,7 +287,7 @@ note = [
       comments: Faker::Lorem.paragraph,
       family: family
     )
-
+    # Create random set of children associated with the families created before
     total_children = family.home_child_count + family.home_young_child_count
 
     total_children.times do |index|
@@ -308,11 +308,11 @@ note = [
         item_needed_diaperid: family.partner.organization.item_id_to_display_string_map.key(Partners::Child::CHILD_ITEMS.sample)
       )
 
-      # Associate 1 to 5 items with each child (Assuming a method to do so)
-      (1..5).to_a.sample.times do
-        item = family.partner.organization.items.sample
+      # Ensure 1 to 5 unique items are associated with each child
+      unique_items = family.partner.organization.items.sample(5).sample(rand(1..5))
+      unique_items.each do |item|
+        # Assuming a method to associate an item with a child exists, replace `<<` with that method if different
         child.items << item
-        # If a child-items association doesn't exist, you'll need to manually create it or adjust this logic to fit your model's structure.
       end
     end
   end


### PR DESCRIPTION
WIP - 

Update1:
What works: 

- Creation and editing of a child with multiple items, including adjusted seeds to reflect that upon db reset.
- Creation of requests for specific children that pass, but without considering the # of requested items (that need to be verified with PMs due to lack of DoD).

Missing: 
Needs testing and front-end adjustments and improvements. Also, in general, there could be some code that eventually is not necessary.

There could be other tests that break now due to changes in business logic/models. That hasn't been assessed so far, but will be soon.